### PR TITLE
fix(tls): reload only when secret data changes

### DIFF
--- a/pkg/tls/manager.go
+++ b/pkg/tls/manager.go
@@ -188,22 +188,26 @@ func (m *Manager) watch(ctx context.Context) {
 }
 
 func (m *Manager) write(secret *v1.Secret) {
+	changed := false
+
 	for _, path := range m.config.Paths.CertificateAuthorityPaths {
-		m.writeFile(path, secret.Data["ca.crt"])
+		changed = m.writeFile(path, secret.Data["ca.crt"]) || changed
 	}
 
 	for _, path := range m.config.Paths.CertificatePaths {
-		m.writeFile(path, secret.Data["tls.crt"])
+		changed = m.writeFile(path, secret.Data["tls.crt"]) || changed
 	}
 
 	for _, path := range m.config.Paths.CertificateKeyPaths {
-		m.writeFile(path, secret.Data["tls.key"])
+		changed = m.writeFile(path, secret.Data["tls.key"]) || changed
 	}
 
-	m.config.OnUpdate()
+	if changed {
+		m.config.OnUpdate()
+	}
 }
 
-func (m *Manager) writeFile(path string, data []byte) {
+func (m *Manager) writeFile(path string, data []byte) bool {
 	log := m.logger.WithFields(log.Fields{
 		"path": path,
 	})
@@ -223,14 +227,14 @@ func (m *Manager) writeFile(path string, data []byte) {
 				log.Fatal(err)
 			}
 
-			return
+			return true
 		}
 
 		m.logger.Fatal(err)
 	}
 
 	if bytes.Equal(existingData, data) {
-		return
+		return false
 	}
 
 	log.Info("file contents changed, updating file")
@@ -239,4 +243,6 @@ func (m *Manager) writeFile(path string, data []byte) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	return true
 }

--- a/pkg/tls/manager_test.go
+++ b/pkg/tls/manager_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 VEXXHOST, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tls
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestWriteCallsOnUpdateOnlyWhenFilesChange(t *testing.T) {
+	dir := t.TempDir()
+	updates := 0
+
+	manager := &Manager{
+		config: &Config{
+			Paths: &WritePathConfig{
+				CertificateAuthorityPaths: []string{filepath.Join(dir, "ca.crt")},
+				CertificatePaths:          []string{filepath.Join(dir, "tls.crt")},
+				CertificateKeyPaths:       []string{filepath.Join(dir, "tls.key")},
+			},
+			OnUpdate: func() {
+				updates++
+			},
+		},
+		logger: log.NewEntry(log.New()),
+	}
+
+	secret := &v1.Secret{
+		Data: map[string][]byte{
+			"ca.crt":  []byte("ca"),
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		},
+	}
+
+	manager.write(secret)
+	assert.Equal(t, 1, updates)
+
+	manager.write(secret)
+	assert.Equal(t, 1, updates)
+
+	secret.Data["tls.crt"] = []byte("rotated-cert")
+	manager.write(secret)
+	assert.Equal(t, 2, updates)
+}
+
+func TestWriteFileReportsWhetherFileChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tls.crt")
+
+	manager := &Manager{
+		logger: log.NewEntry(log.New()),
+	}
+
+	assert.True(t, manager.writeFile(path, []byte("cert")))
+	assert.False(t, manager.writeFile(path, []byte("cert")))
+	assert.True(t, manager.writeFile(path, []byte("rotated-cert")))
+
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("rotated-cert"), data)
+}


### PR DESCRIPTION
## Summary

- Track whether CA/certificate/key files actually change before invoking reload callbacks.
- Avoid firing reloads during informer resyncs when Secret data is unchanged.
- Add focused tests for initial writes, no-op rewrites, and cert rotation.

## Validation

- `nix-shell -p go --run 'gofmt -w pkg/tls/manager.go pkg/tls/manager_test.go && go test ./...'`