### PR TITLE
Build multi-arch container images

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: bfv6ppq3zq
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # Copyright (c) 2024 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 WORKDIR /src
 COPY go.mod go.sum /src/
 RUN go mod download
 COPY . /src
-RUN CGO_ENABLED=0 go build -o /pod-tls-sidecar main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /pod-tls-sidecar main.go
 
 FROM ubuntu
 COPY --from=builder /pod-tls-sidecar /usr/bin/pod-tls-sidecar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Copyright (c) 2024 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS builder
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS builder
 WORKDIR /src
 COPY go.mod go.sum /src/
 RUN go mod download
 COPY . /src
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /pod-tls-sidecar main.go
+RUN CGO_ENABLED=0 go build -o /pod-tls-sidecar main.go
 
 FROM ubuntu
 COPY --from=builder /pod-tls-sidecar /usr/bin/pod-tls-sidecar


### PR DESCRIPTION
## Summary
- build the Go binary for the Docker target OS and architecture using BuildKit target args
- publish linux/amd64 and linux/arm64 image variants from the image workflow